### PR TITLE
Revision no longer contains duplicate logic

### DIFF
--- a/src/Listener/RevisionListener.php
+++ b/src/Listener/RevisionListener.php
@@ -79,7 +79,7 @@ class RevisionListener
         }
 
         if ($this->revision === null) {
-            throw new \RuntimeException("No Revision set for current flush.");
+            throw new \RuntimeException('No Revision set for current flush.');
         }
 
         $em->persist($this->revision);

--- a/src/Resolver/RevisionResolver.php
+++ b/src/Resolver/RevisionResolver.php
@@ -41,23 +41,7 @@ class RevisionResolver implements RevisionResolverInterface
      */
     public function getRevisionableFields(EntityManagerInterface $em, $entity)
     {
-        if (null === ($annotation = $this->getRevisionAnnotation($em, $entity))) {
-            return [];
-        }
-
-        $mutation_class = !empty($annotation->class) ? $annotation->class : get_class($entity) . 'Mutation';
-        $metadata       = $em->getClassMetadata(get_class($entity));
-        $mutation_meta  = $em->getClassMetadata($mutation_class);
-
-        return array_merge(
-            array_values(array_intersect(
-                $metadata->getFieldNames(),
-                $mutation_meta->getFieldNames()
-            )),
-            array_values(array_intersect(
-                $metadata->getAssociationNames(),
-                $mutation_meta->getAssociationNames()
-            ))
-        );
+        $metadata = $em->getClassMetadata(get_class($entity));
+        return array_merge($metadata->getFieldNames(), $metadata->getAssociationNames());
     }
 }

--- a/src/Revision.php
+++ b/src/Revision.php
@@ -11,10 +11,5 @@ use Hostnet\Component\EntityTracker\Annotation\Tracked;
  */
 class Revision extends Tracked
 {
-    /**
-     * Mutated class used to determine the changes of
-     *
-     * @var string
-     */
-    public $class = '';
+
 }

--- a/test/Listener/RevisionListenerTest.php
+++ b/test/Listener/RevisionListenerTest.php
@@ -54,7 +54,7 @@ class RevisionListenerTest extends \PHPUnit_Framework_TestCase
     {
         $this->resolver
             ->expects($this->never())
-            ->method('getRevisionFields');
+            ->method('getRevisionableFields');
 
         $event    = new EntityChangedEvent($this->em, new \stdClass(), $this->entity, []);
         $listener = new RevisionListener($this->resolver, $this->factory);

--- a/test/Resolver/RevisionResolverTest.php
+++ b/test/Resolver/RevisionResolverTest.php
@@ -17,12 +17,12 @@ class RevisionResolverTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->provider = $this
-            ->getMockBuilder("Hostnet\Component\EntityTracker\Provider\EntityAnnotationMetadataProvider")
+            ->getMockBuilder('Hostnet\Component\EntityTracker\Provider\EntityAnnotationMetadataProvider')
             ->disableOriginalConstructor()
             ->getMock();
 
         $this->em = $this
-            ->getMockBuilder("Doctrine\ORM\EntityManagerInterface")
+            ->getMockBuilder('Doctrine\ORM\EntityManagerInterface')
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -38,8 +38,8 @@ class RevisionResolverTest extends \PHPUnit_Framework_TestCase
 
         $this->provider
             ->expects($this->once())
-            ->method("getAnnotationFromEntity")
-            ->with($this->em, $entity, "Hostnet\Component\EntityRevision\Revision");
+            ->method('getAnnotationFromEntity')
+            ->with($this->em, $entity, 'Hostnet\Component\EntityRevision\Revision');
 
         $this->resolver->getRevisionAnnotation($this->em, $entity);
     }
@@ -47,43 +47,19 @@ class RevisionResolverTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers ::getRevisionableFields
      */
-    public function testGetRevisionableFieldsNoAnnotation()
-    {
-        $entity = new \stdClass();
-
-        $this->provider
-            ->expects($this->once())
-            ->method("getAnnotationFromEntity")
-            ->willReturn(null);
-
-        $this->assertEmpty($this->resolver->getRevisionableFields($this->em, $entity));
-    }
-
-    /**
-     * @covers ::getRevisionableFields
-     */
     public function testGetRevisionableFields()
     {
-        $entity        = new \stdClass();
-        $metadata      = $this->getMock("\Doctrine\Common\Persistence\Mapping\ClassMetadata");
-        $metadata_meta = $this->getMock("\Doctrine\Common\Persistence\Mapping\ClassMetadata");
-
-        $this->provider
-            ->expects($this->once())
-            ->method("getAnnotationFromEntity")
-            ->willReturnOnConsecutiveCalls(new Revision());
-
-        $metadata->expects($this->once())->method("getFieldNames")->willReturn(["id"]);
-        $metadata->expects($this->once())->method("getAssociationNames")->willReturn(["test"]);
-        $metadata_meta->expects($this->once())->method("getFieldNames")->willReturn(["id"]);
-        $metadata_meta->expects($this->once())->method("getAssociationNames")->willReturn(["test"]);
+        $entity   = new \stdClass();
+        $metadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $metadata->expects($this->once())->method('getFieldNames')->willReturn(['id']);
+        $metadata->expects($this->once())->method('getAssociationNames')->willReturn(['test']);
 
         $this->em
-            ->expects($this->exactly(2))
-            ->method("getClassMetadata")
-            ->withConsecutive([get_class($entity)], [get_class($entity) . "Mutation"])
-            ->willReturnOnConsecutiveCalls($metadata, $metadata_meta);
+            ->expects($this->once())
+            ->method('getClassMetadata')
+            ->with(get_class($entity))
+            ->willReturn($metadata);
 
-        $this->assertEquals(["id", "test"], $this->resolver->getRevisionableFields($this->em, $entity));
+        $this->assertEquals(['id', 'test'], $this->resolver->getRevisionableFields($this->em, $entity));
     }
 }


### PR DESCRIPTION
Due to the previously tight coupling with mutation, there was some duplicate logic for revisions. The resolver no longer uses the *Mutation.php nor Revision::$class properties to determine revisionable fields.
