### PR TITLE
Removed info-line to prevent cluttering log files

### DIFF
--- a/src/Listener/RevisionListener.php
+++ b/src/Listener/RevisionListener.php
@@ -79,7 +79,6 @@ class RevisionListener
     public function postFlush(PostFlushEventArgs $event)
     {
         $this->revision = null;
-        $this->logger->info(sprintf('Revision state reset, next flush will contain a new revision'));
     }
 
     /**


### PR DESCRIPTION
The removed line is cluttering log files a lot. Removed it since it doesn't provide any useful information.