### PR TITLE
entity-tracker-component 2.0.0 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 language: php
-php:
-  - 7.0
-  - 5.6
-  - 5.5
-  - hhvm
+
+matrix:
+    include:
+        - php: 5.6
+        - php: 7.0
+        - php: 7.0
+          env: deps=lowest
+        - php: 7.1
+        - php: hhvm
+    allow_failures:
+        - php: hhvm
 
 install:
-    - composer install --prefer-source
+    - if [ -z "$deps" ]; then composer install; fi;
+    - if [ "$deps" = "lowest" ]; then composer update --prefer-lowest -n; fi;

--- a/composer.json
+++ b/composer.json
@@ -1,37 +1,39 @@
 {
-    "name": "hostnet/entity-revision-component",
-    "description": "Listens to an event so revisions can be made",
-    "license": "MIT",
+    "name":              "hostnet/entity-revision-component",
+    "description":       "Listens to an event so revisions can be made",
+    "license":           "MIT",
     "require": {
-        "php"                              : "7.0.*|>=5.5",
-        "doctrine/orm"                     : "2.*",
-        "hostnet/entity-tracker-component" : "1.*",
-        "psr/log"                          : "1.*"
+        "php":                              "5.*,>=5.6||7.*",
+        "doctrine/orm":                     "^2.4.0",
+        "hostnet/entity-tracker-component": "^1.2.0||^2.0.0",
+        "psr/log":                          "^1.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit" : "4.*"
+        "phpunit/phpunit": "^5.5.0"
     },
     "minimum-stability": "stable",
     "autoload": {
         "psr-4": {
-           "Hostnet\\Component\\EntityRevision\\" : "src/"
+            "Hostnet\\Component\\EntityRevision\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-           "Hostnet\\Component\\EntityRevision\\" : "test/"
+            "Hostnet\\Component\\EntityRevision\\": "test/"
         }
     },
     "archive": {
-        "exclude": [ "/test" ]
+        "exclude": [
+            "/test"
+        ]
     },
     "authors": [
         {
-            "name": "Iltar van der Berg",
+            "name":  "Iltar van der Berg",
             "email": "ivanderberg@hostnet.nl"
         },
         {
-            "name": "Yannick de Lange",
+            "name":  "Yannick de Lange",
             "email": "ydelange@hostnet.nl"
         }
     ]

--- a/test/Listener/RevisionListenerTest.php
+++ b/test/Listener/RevisionListenerTest.php
@@ -18,12 +18,12 @@ class RevisionListenerTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $revision_loc   = 'Hostnet\Component\EntityRevision';
-        $this->em       = $this->getMock('Doctrine\ORM\EntityManagerInterface');
-        $this->factory  = $this->getMock($revision_loc . '\Factory\RevisionFactoryInterface');
-        $this->resolver = $this->getMock($revision_loc . '\Resolver\RevisionResolverInterface');
-        $this->entity   = $this->getMock($revision_loc . '\RevisionableInterface');
-        $this->revision = $this->getMock($revision_loc . '\RevisionInterface');
-        $this->logger   = $this->getMock('Psr\Log\LoggerInterface');
+        $this->em       = $this->createMock('Doctrine\ORM\EntityManagerInterface');
+        $this->factory  = $this->createMock($revision_loc . '\Factory\RevisionFactoryInterface');
+        $this->resolver = $this->createMock($revision_loc . '\Resolver\RevisionResolverInterface');
+        $this->entity   = $this->createMock($revision_loc . '\RevisionableInterface');
+        $this->revision = $this->createMock($revision_loc . '\RevisionInterface');
+        $this->logger   = $this->createMock('Psr\Log\LoggerInterface');
     }
 
     public function testPreFlush()
@@ -73,7 +73,7 @@ class RevisionListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->factory
             ->expects($this->never())
-            ->method('never');
+            ->method('createRevision');
 
         $event    = new EntityChangedEvent($this->em, $this->entity, $this->entity, []);
         $listener = new RevisionListener($this->resolver, $this->factory, $this->logger);
@@ -134,8 +134,8 @@ class RevisionListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testOnEntityChanged()
     {
-        $r1 = $this->getMock('Hostnet\Component\EntityRevision\RevisionInterface');
-        $r2 = $this->getMock('Hostnet\Component\EntityRevision\RevisionInterface');
+        $r1 = $this->createMock('Hostnet\Component\EntityRevision\RevisionInterface');
+        $r2 = $this->createMock('Hostnet\Component\EntityRevision\RevisionInterface');
 
         $history = new Revision();
         $this->resolver

--- a/test/Resolver/RevisionResolverTest.php
+++ b/test/Resolver/RevisionResolverTest.php
@@ -43,7 +43,7 @@ class RevisionResolverTest extends \PHPUnit_Framework_TestCase
     public function testGetRevisionableFields()
     {
         $entity   = new \stdClass();
-        $metadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $metadata = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
         $metadata->expects($this->once())->method('getFieldNames')->willReturn(['id']);
         $metadata->expects($this->once())->method('getAssociationNames')->willReturn(['test']);
 


### PR DESCRIPTION
* use entity-tracker-component ^2.0.0
* dropped support for php 5.5
* phpunit 5.5
* test lowest deps in travis too